### PR TITLE
Add 'Personal Links' column with any social media links if added

### DIFF
--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -25,7 +25,11 @@ const getFormattedPersonalLinks = (links: string | null) => {
     return null;
   }
 
-  return links.trim().split(/\s+/).map(link => formatLink(link));
+  return links
+    .trim()
+    .split(/\s+/)
+    .filter(link => link.includes("."))
+    .map(link => formatLink(link));
 };
 
 // Utility function to ensure the link has 'https://' prefix

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -18,6 +18,16 @@ export type Winner = {
     embedding_description: number[];
 };
 
+// Parses the user-entered personal links to a string and returns 
+// an array of valid URLs. If none, returns null
+const getFormattedPersonalLinks = (links: string | null) => {
+  if (!links || links == "" || links === " " || links === "-") {
+    return null;
+  }
+
+  return links.trim().split(/\s+/).map(link => formatLink(link));
+};
+
 // Utility function to ensure the link has 'https://' prefix
 const formatLink = (link: string | null) => {
     if (link && !link.startsWith('http://') && !link.startsWith('https://')) {
@@ -37,11 +47,25 @@ export const columns: ColumnDef<Winner>[] = [
     },
     {
         accessorKey: "link",
-        header: "Link",
+        header: "MR Link",
         cell: (cell) => {
             const link = formatLink(cell.row.original.link);
             return link ? <a className="underline" href={link} target="_blank" rel="noopener noreferrer">Link</a> : null;
         },
+    },
+    {
+      accessorKey: "personal_links",
+      header: "Personal Links",
+      cell: (cell) => {
+        const personalLinks = getFormattedPersonalLinks(cell.row.original.personal_links);
+
+        return personalLinks?.map((personalLink, index) => (
+          <span>
+            <a className="underline" href={personalLink} target="_blank" rel="noopener noreferrer"> {index + 1}</a>
+            {(index + 1) !== personalLinks.length ? "," : null}
+          </span>
+        ))
+      },
     },
     {
         accessorKey: "description",


### PR DESCRIPTION
@nqureshi 

I wanted to contact someone from EV Winners list but couldn't find their social media, because of which I then tinkered around in the repo to see if this data was present and if I could add it to the website, which I was able to.

This PR adds a new `Personal Links` column and if the winner had entered any links, adds them to the table like so:

![image](https://github.com/user-attachments/assets/527b9321-4f76-4e89-9011-200e5fa1f915)
